### PR TITLE
Profile flag in SVRTK

### DIFF
--- a/include/svrtk/Profiling.h
+++ b/include/svrtk/Profiling.h
@@ -27,7 +27,7 @@
 
 /// End measurement of execution time of current code block
 #ifdef  SVRTK_TOOL
-#define SVRTK_END_TIMING      if (debug) MIRTK_END_TIMING
+#define SVRTK_END_TIMING      if (debug || profile) MIRTK_END_TIMING
 #else
-#define SVRTK_END_TIMING      if (_debug) MIRTK_END_TIMING
+#define SVRTK_END_TIMING      if (_debug || _profile) MIRTK_END_TIMING
 #endif

--- a/include/svrtk/Reconstruction.h
+++ b/include/svrtk/Reconstruction.h
@@ -248,6 +248,9 @@ namespace svrtk {
         /// Debug mode
         bool _debug;
 
+        /// Profile output mode
+        bool _profile;
+
         /// Verbose mode
         bool _verbose;
         ostream _verbose_log {cout.rdbuf()};
@@ -729,6 +732,16 @@ namespace svrtk {
         /// Disable debug mode
         inline void DebugOff() {
             _debug = false;
+        }
+
+        /// Enable debug mode
+        inline void ProfileOn() {
+            _profile = true;
+        }
+
+        /// Disable debug mode
+        inline void ProfileOff() {
+            _profile = false;
         }
 
         /// Enable verbose mode

--- a/include/svrtk/Reconstruction.h
+++ b/include/svrtk/Reconstruction.h
@@ -734,12 +734,12 @@ namespace svrtk {
             _debug = false;
         }
 
-        /// Enable debug mode
+        /// Enable profiling mode
         inline void ProfileOn() {
             _profile = true;
         }
 
-        /// Disable debug mode
+        /// Disable profiling mode
         inline void ProfileOff() {
             _profile = false;
         }

--- a/tools/reconstruct.cc
+++ b/tools/reconstruct.cc
@@ -115,6 +115,7 @@ int main(int argc, char **argv) {
     int iterations = 3;
     int srIterations = 7;
     bool debug = false;
+    bool profile = false;
     double sigma = 20;
     double resolution = 0.75;
     double lambda = 0.02;

--- a/tools/reconstructCardiac.cc
+++ b/tools/reconstructCardiac.cc
@@ -105,6 +105,7 @@ int main(int argc, char **argv) {
     unique_ptr<RealImage> mask;
     int iterations = 4;
     bool debug = false;
+    bool profile = false;
     double sigma = 20;
     double motionSigma = 0;
     double resolution = 0.75;
@@ -222,6 +223,7 @@ int main(int argc, char **argv) {
         ("log_prefix", value<string>(&logID), "Prefix for the log file.")
         ("info", value<string>(&infoFilename), "File name for slice information in tab-separated columns.")
         ("debug", bool_switch(&debug), "Debug mode - save intermediate results.")
+        ("profile", bool_switch(&profile), "Profile - output profiling timings (also on in debug mode)")
         ("remote", bool_switch(&remoteFlag), "Run SVR registration as remote functions in case of memory issues. [Default: false]")
         ("no_log", bool_switch(&noLog), "Do not redirect cout and cerr to log files.");
 
@@ -470,6 +472,12 @@ int main(int argc, char **argv) {
         reconstruction.DebugOn();
     else
         reconstruction.DebugOff();
+
+    //Set profiling mode
+    if (profile)
+        reconstruction.ProfileOn();
+    else
+        reconstruction.ProfileOff();
 
     //Set NMI bins for registration
     reconstruction.SetNMIBins(nmiBins);

--- a/tools/reconstructCardiacVelocity.cc
+++ b/tools/reconstructCardiacVelocity.cc
@@ -98,6 +98,7 @@ int main(int argc, char **argv) {
     int templateNumber = 0;
     unique_ptr<RealImage> mask;
     bool debug = false;
+    bool profile = false;
     double sigma = 20;
     double resolution = 1.25;
     int numCardPhase = 15;
@@ -439,6 +440,13 @@ int main(int argc, char **argv) {
         reconstruction.DebugOn();
     else
         reconstruction.DebugOff();
+
+    //Set profiling mode
+    if (profile)
+        reconstruction.ProfileOn();
+    else
+        reconstruction.ProfileOff();
+    cout << "Profiling: " << profile << endl;
 
     //Set adaptive regularisation option flag
     reconstruction.SetAdaptiveRegularisation(adaptiveRegularisation);

--- a/tools/reconstructFFD.cc
+++ b/tools/reconstructFFD.cc
@@ -121,6 +121,7 @@ int main(int argc, char **argv) {
     int iterations = 3;
     int srIterations = 5;
     bool debug = false;
+    bool profile = false;
     double sigma = 20;
     double resolution = 0.85;
     double lambda = 0.0225;


### PR DESCRIPTION
New 'profile' flag that provides alternative option to output profiling information without using the more vebose 'debug' flag. Used by reconstructCardiac tool.