### PR TITLE
Parallelisation bug fix. 

### DIFF
--- a/include/svrtk/Reconstruction.h
+++ b/include/svrtk/Reconstruction.h
@@ -128,8 +128,8 @@ namespace svrtk {
         Array<MultiLevelFreeFormTransformation*> _global_mffd_transformations;
 
         /// Indicator whether slice has an overlap with volumetric mask
-        Array<bool> _slice_inside;
-        Array<bool> _slice_insideSF;
+        deque<bool> _slice_inside;
+        deque<bool> _slice_insideSF;
 
         /// Flag to say whether the template volume has been created
         bool _template_created;

--- a/include/svrtk/ReconstructionCardiac4D.h
+++ b/include/svrtk/ReconstructionCardiac4D.h
@@ -103,7 +103,7 @@ namespace svrtk {
         Array<int> _force_excluded_locs;
 
         // Slice Excluded
-        Array<bool> _slice_excluded;
+        deque<bool> _slice_excluded;
 
         // Temporal Weighting Tukey Window Edge Percent
         // applies to sinc temporal weighting only

--- a/include/svrtk/ReconstructionDWI.h
+++ b/include/svrtk/ReconstructionDWI.h
@@ -45,7 +45,7 @@ namespace svrtk {
 
         Array<RigidTransformation> _transformations;
 
-        Array<bool> _slice_inside;
+        deque<bool> _slice_inside;
 
         RealImage _reconstructed;
 

--- a/include/svrtk/Utility.h
+++ b/include/svrtk/Utility.h
@@ -313,6 +313,15 @@ namespace svrtk::Utility {
 
     //-------------------------------------------------------------------
 
+    /// Clear and resize memory for deque
+    template<typename VectorType>
+    inline void ClearAndResize(deque<VectorType>& vectorVar, size_t reserveSize, const VectorType& defaultValue = VectorType()) {
+        vectorVar.clear();
+        vectorVar.resize(reserveSize, defaultValue);
+    }
+
+    //-------------------------------------------------------------------
+
     /**
      * @brief Binarise mask.
      * If template image has been masked instead of creating the mask in separate

--- a/src/ReconstructionCardiac4D.cc
+++ b/src/ReconstructionCardiac4D.cc
@@ -222,7 +222,7 @@ namespace svrtk {
         ClearAndReserve(_stack_loc_index, reserve_size);
         ClearAndReserve(_stack_dyn_index, reserve_size);
         ClearAndReserve(_transformations, reserve_size);
-        ClearAndReserve(_slice_excluded, reserve_size);
+        _slice_excluded.clear();
         ClearAndReserve(_slice_svr_card_index, reserve_size);
         if (!probability_maps.empty())
             ClearAndReserve(_probability_maps, reserve_size);
@@ -540,7 +540,7 @@ namespace svrtk {
             memset(_simulated_slices[i].Data(), 0, sizeof(RealPixel) * _simulated_slices[i].NumberOfVoxels());
 
         //Initialise indicator of images having overlap with volume
-        _slice_inside = Array<bool>(_slices.size(), true);
+        _slice_inside = deque<bool>(_slices.size(), true);
 
         //Simulate images
         Parallel::SimulateStacksCardiac4D simulatestacks(this);


### PR DESCRIPTION
Parallelisation bug fix. Array<bool>, i.e. vector<bool>, is not thread-safe. Changing this to use deque<bool> instead for thread-safety to avoid random variations in output.